### PR TITLE
update to latest purescript-strings, fix all versions in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
   "name": "purescript-path",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "PureScript tools for working with paths.",
   "license": "MIT",
   "dependencies": {
-    "purescript-arrays": "~0.2.1",
-    "purescript-foldable-traversable": "~0.1.3",
-    "purescript-strings": "~0.2.1",
-    "purescript-maybe": "~0.2.1"
+    "purescript-arrays":                "~0.2.1",
+    "purescript-foldable-traversable":  "~0.1.3",
+    "purescript-strings":               "~0.3.0",
+    "purescript-maybe":                 "~0.2.1"
   }
 }

--- a/src/System/Path/Unix.purs
+++ b/src/System/Path/Unix.purs
@@ -4,8 +4,9 @@ module System.Path.Unix where
 
   import Data.Array (filter, last)
   import Data.Foldable (foldl)
-  import Data.Maybe (fromMaybe)
+  import Data.Maybe (fromMaybe, Maybe(..))
   import Data.Path (FilePath())
+  import Data.Char (Char(), charString)
   import Data.String (charAt, drop, joinWith, length, split)
 
   infixr 5 </>
@@ -19,10 +20,10 @@ module System.Path.Unix where
   (</>) p p'                                = p ++ "/" ++ p'
 
   absolute :: FilePath -> Boolean
-  absolute p = charAt 0 p == "/"
+  absolute p = (charString <$> charAt 0 p) == Just "/"
 
   hasTrailing :: FilePath -> Boolean
-  hasTrailing p = charAt (length p - 1) p == "/"
+  hasTrailing p = (charString <$> charAt (length p - 1) p) == Just "/"
 
   joinPath :: [FilePath] -> FilePath
   joinPath ps = foldl (</>) "" $ nonEmpty ps


### PR DESCRIPTION
Review / merge by @joneshf.

Current version is `0.2.2`, this API is compatible so could be a patch fix `0.2.3`.
